### PR TITLE
Fix bug with select IN

### DIFF
--- a/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
+++ b/MicroOrm.Pocos.SqlGenerator.Tests/SqlGeneratorTests.cs
@@ -55,6 +55,15 @@ namespace MicroOrm.Pocos.SqlGenerator.Tests
 
             Assert.IsTrue(sql.Contains("WHERE [MyTable].[Description] IN @Description"));
         }
+
+        [TestMethod]
+        public void GetWhere_TestIEnumerableFilter1()
+        {
+            var sqlGenerator = new SqlGenerator<MyObject>();
+            var sql = sqlGenerator.GetSelect(new { Description = 123 });
+
+            Assert.IsTrue(sql.Contains("WHERE [MyTable].[Description] = @Description"));
+        }
     }
 
     [StoredAs("MyTable")]

--- a/MicroOrm.Pocos.SqlGenerator/SqlGenerator.cs
+++ b/MicroOrm.Pocos.SqlGenerator/SqlGenerator.cs
@@ -307,7 +307,7 @@ namespace MicroOrm.Pocos.SqlGenerator
                 {
                     return string.Format("[{0}].[{1}] IS NULL", this.TableName, columnName);
                 }
-                else if(values is IEnumerable)
+                else if((values as IEnumerable) != null && !(values is string))
                 {
                     return string.Format("[{0}].[{1}] IN @{2}", this.TableName, columnName, propertyName);
                 }


### PR DESCRIPTION
Fixed a bug with SELECT WHERE param IN @param vs SELECT WHERE param = @param.  Needed to check that is not string also.